### PR TITLE
ci: use x64 for naming instead of x86

### DIFF
--- a/.github/workflows/build-installers.yaml
+++ b/.github/workflows/build-installers.yaml
@@ -78,7 +78,7 @@ jobs:
             electron-builder-options: --arm64
           - name: Intel
             matrix: intel
-            artifact-name: x86
+            artifact-name: x64
             deb-platform: amd64
             electron-builder-options: --x64
         exclude:


### PR DESCRIPTION
This matches the other climate repos more directly