### PR TITLE
Check both meta_ and not meta_ for metadata

### DIFF
--- a/app/crud/chia.py
+++ b/app/crud/chia.py
@@ -159,7 +159,12 @@ class ClimateWareHouseCrud(object):
                 continue
 
             org_metadata: Dict[str, str] = metadata_by_id.get(org_uid)
-            metadata: Dict = json.loads(org_metadata.get(asset_id, "{}"))
+            metadata = dict()
+            # some versions perpended "meta_" to the key, so check both ways
+            if asset_id in org_metadata:
+                metadata = json.loads(org_metadata.get(asset_id, "{}"))
+            elif f"meta_{asset_id}" in org_metadata:
+                metadata = json.loads(org_metadata.get(f"meta_{asset_id}", "{}"))
 
             unit["organization"] = org
             unit["token"] = metadata


### PR DESCRIPTION
Due to version differences, sometimes the metadata is prepended with "meta_". In order to maximize version compatibility, this code looks for both versions. This allows testing to use various versions without the explorer failing to find tokenization.

It checks the non-prepended version first, and if not found uses the "meta_" prepend.