### PR TITLE
fix some odd incompatibilities

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -2,4 +2,3 @@
 line_length = 120
 profile=black
 skip_gitignore=true
-add_imports=from __future__ import annotations

--- a/app/api/v1/activities.py
+++ b/app/api/v1/activities.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends

--- a/app/api/v1/keys.py
+++ b/app/api/v1/keys.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Optional
 
 from blspy import G1Element, PrivateKey

--- a/app/api/v1/tokens.py
+++ b/app/api/v1/tokens.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import json
 from typing import Any, Dict, Tuple
 

--- a/app/api/v1/transactions.py
+++ b/app/api/v1/transactions.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import List, Optional
 
 from chia.rpc.wallet_rpc_client import WalletRpcClient


### PR DESCRIPTION
The following line `from __future__ import annotations` seems to cause some strange incompatibility with the (afaict bizarre and wrong) way we are using fastapi.

However, this may also be some problem with versions of pydantic (see https://github.com/tiangolo/fastapi/discussions/8588)

Also revert back to untyped `disallow` decorator