### PR TITLE
fix: issues with token pydantic classes and forward refs

### DIFF
--- a/app/api/dependencies.py
+++ b/app/api/dependencies.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import enum
-from contextlib import asynccontextmanager, AbstractAsyncContextManager
+from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from pathlib import Path
 from typing import AsyncGenerator, AsyncIterator
 

--- a/app/schemas/token.py
+++ b/app/schemas/token.py
@@ -74,11 +74,12 @@ class DetokenizationFileParseResponse(BaseModel):
     gateway_coin_spend: ChiaJsonObject
 
 
-class DetokenizationFileRequest(BaseModel):
-    class _TokenOnChain(TokenOnChainBase):
-        detokenization: DetokenizationTailMetadata
+class _TokenOnChain_Detokenize(TokenOnChainBase):
+    detokenization: DetokenizationTailMetadata
 
-    token: _TokenOnChain
+
+class DetokenizationFileRequest(BaseModel):
+    token: _TokenOnChain_Detokenize
     payment: PaymentBase
 
 
@@ -88,11 +89,12 @@ class DetokenizationFileResponse(BaseModel):
     tx: Transaction
 
 
-class PermissionlessRetirementTxRequest(BaseModel):
-    class _TokenOnChain(TokenOnChainBase):
-        permissionless_retirement: PermissionlessRetirementTailMetadata
+class _TokenOnChain_Permissionless(TokenOnChainBase):
+    permissionless_retirement: PermissionlessRetirementTailMetadata
 
-    token: _TokenOnChain
+
+class PermissionlessRetirementTxRequest(BaseModel):
+    token: _TokenOnChain_Permissionless
     payment: RetirementPaymentWithPayer
 
 

--- a/tests/test_crud_chia.py
+++ b/tests/test_crud_chia.py
@@ -5,7 +5,7 @@ from unittest import mock
 
 import pytest
 
-from app import crud
+from app import crud, schemas
 
 
 class TestClimateWareHouseCrud:
@@ -286,3 +286,44 @@ class TestClimateWareHouseCrud:
 
         print(f"EMLEML: {response}")
         assert response == test_response
+
+    def test_PermissionlessRetirementTxRequest(self) -> None:
+        test_data = {
+            "token": {
+                "org_uid": "cf7af8da584b6c115ba8247c5cdd05506c3b3c5c632ed975cc2b16262493e2bd",
+                "warehouse_project_id": "c9b98579-debb-49f3-b417-0adbae4ed5c7",
+                "vintage_year": "2099",
+                "sequence_num": 0,
+                "asset_id": "0x8df0a9aa3739e24467b8a6409b49efe355dd4999a51215aed1f944314af07c60",
+                "index": "0x8b0aa9633464b5437f4b980b864a3ab5dda49e6a754ef2b1cde6d30fb28a9330",
+                "public_key": "0x9650dc15356ba1fe3a48e50daa55ac3dfde5323226922c9bf09aae1bd9612105f323e573cfa0778c681467a0c62bc315",
+                "permissionless_retirement": {
+                    "signature": "0xaa1f6b71999333761fbd9eb914ce5ab1c3acb83e7fa7eb5b59c226f20b644c835f8238edbe3ddfeed1a916f0307fe1200174a211b8169ace5afcd9162f88b46565f3ffbbf6dfdf8d154e6337e30829c23ab3f6796d9a319bf0d9168685541d62",
+                    "mod_hash": "0x36ab0a0666149598070b7c40ab10c3aaff51384d4ad4544a1c301636e917c039",
+                },
+            },
+            "payment": {"amount": 5, "fee": 5, "beneficiary_name": "fred", "beneficiary_address": "bar"},
+        }
+
+        schemas.PermissionlessRetirementTxRequest.parse_obj(test_data)
+
+    def test_DetokenizationFileRequest(self) -> None:
+        test_data = {
+            "token": {
+                "org_uid": "cf7af8da584b6c115ba8247c5cdd05506c3b3c5c632ed975cc2b16262493e2bd",
+                "warehouse_project_id": "c9b98579-debb-49f3-b417-0adbae4ed5c7",
+                "vintage_year": "2099",
+                "sequence_num": 0,
+                "asset_id": "0x8df0a9aa3739e24467b8a6409b49efe355dd4999a51215aed1f944314af07c60",
+                "index": "0x8b0aa9633464b5437f4b980b864a3ab5dda49e6a754ef2b1cde6d30fb28a9330",
+                "public_key": "0x9650dc15356ba1fe3a48e50daa55ac3dfde5323226922c9bf09aae1bd9612105f323e573cfa0778c681467a0c62bc315",
+                "detokenization": {
+                    "signature": "0xa627c8779c2d8096444d44879294c7d963180c166564e9c9569c23c3a744af514aae03aeaa5e2d5fd12d0c008c1630410e9d4516b58863658f7ac5b35d09d8810fb28ed43b3f6243c645f0bd934b434aac87cd5718dafd87b51d8bf9c821ba24",
+                    "mod_hash": "0xed13201cb8b52b4c7ef851e220a3d2bddd57120e6e6afde2aabe3fcc400765ea",
+                    "public_key": "0xb431835fe9fa64e9bea1bbab1d4bffd15d17d997f3754b2f97c8db43ea173a8b9fa79ac3a7d58c80111fbfdd4e485f0d",
+                },
+            },
+            "payment": {"amount": 5, "fee": 5, "beneficiary_name": "fred", "beneficiary_address": "bar"},
+        }
+
+        schemas.DetokenizationFileRequest.parse_obj(test_data)


### PR DESCRIPTION
pydantic and `from __future__ import annotations` can interact wrt forward refs in strange ways.

Resolve this by using specific classes defined earlier for `DetokenizationFileRequest` and `PermissionlessRetirementTxRequest`

Added two tests that construct these from data. Probably needs tests to construct all the pydantic classes from expected JSON/dicts.