### PR TITLE
use importlib to get version instead of parsing pyproject.toml

### DIFF
--- a/app/api/v1/cron.py
+++ b/app/api/v1/cron.py
@@ -132,7 +132,7 @@ async def _scan_token_activity(
 
             # This is causing logging for benign errors, so commenting out for now
             # except json.JSONDecodeError as e:
-               # logger.error(f"Failed to parse JSON for key {key} in organization {org_name}: {str(e)}")
+            # logger.error(f"Failed to parse JSON for key {key} in organization {org_name}: {str(e)}")
             except Exception as e:
                 logger.error(f"An error occurred for organization {org_name} under key {key}: {str(e)}")
 

--- a/app/logger.py
+++ b/app/logger.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
+import importlib.metadata
 import logging
+
 import uvicorn
-import toml
+
 from app.config import settings
 
-# Parse pyproject.toml to get the version
-with open('pyproject.toml', 'r') as toml_file:
-    pyproject = toml.load(toml_file)
-version = pyproject['tool']['poetry']['version']
+version = importlib.metadata.version("Chia Climate Token Driver")
 
 # Define the log format with version
 log_format = f"%(asctime)s,%(msecs)d {version} %(levelname)-8s [%(filename)s:%(lineno)d] %(message)s"


### PR DESCRIPTION
Parsing pyproject.toml would require including that inside the pyinstaller package, which isn't a good idea.

Using importlib is the recommended way to get the version for the application (available since python 3.8)