### PR TITLE
specific activty record via /activities/activity-record

### DIFF
--- a/app/api/v1/activities.py
+++ b/app/api/v1/activities.py
@@ -160,7 +160,7 @@ async def get_activity_by_cw_unit_id(
     (activities, total) = db_crud.select_activity_with_pagination(
         model=models.Activity,
         filters=activity_filters,
-        order_by='desc',
+        order_by=[models.Activity.height.asc()],
         page=page,
         limit=limit,
     )

--- a/app/crud/chia.py
+++ b/app/crud/chia.py
@@ -65,6 +65,10 @@ class ClimateWareHouseCrud(object):
                     raise error_code.internal_server_error(message="API Call Failure")
 
                 data = response.json()
+                if data is None:
+                    # some cadt endpoints return null with no pagination info if no data is found
+                    # to prevent an infinite loop need to assume that there is no data matching the search from this iteration on
+                    return all_data
 
                 all_data.extend(data["data"])  # Add data from the current page
 

--- a/app/crud/chia.py
+++ b/app/crud/chia.py
@@ -70,7 +70,15 @@ class ClimateWareHouseCrud(object):
                     # to prevent an infinite loop need to assume that there is no data matching the search from this iteration on
                     return all_data
 
-                all_data.extend(data["data"])  # Add data from the current page
+                try:
+                    if data["page"] and data["pageCount"] and data["data"]:
+                        all_data.extend(data["data"]) # Add data from the current page
+                    else:
+                        all_data.append(data) # data was not paginated, append and return
+                        return all_data
+                except:
+                    all_data.append(data)  # data was not paginated, append and return
+                    return all_data
 
                 if page >= data["pageCount"]:
                     break  # Exit loop if all pages have been processed
@@ -183,7 +191,7 @@ class ClimateWareHouseCrud(object):
                 warehouse_project_id = unit["issuance"]["warehouseProjectId"]
                 project = project_by_id[warehouse_project_id]
             except (KeyError, TypeError):
-                logger.warning(f"Can not get project by warehouse_project_id: {warehouse_project_id}")
+                logger.warning(f"Can not get project by warehouse_project_id")
                 continue
 
             org_metadata = metadata_by_id.get(unit_org_uid)

--- a/app/crud/chia.py
+++ b/app/crud/chia.py
@@ -57,9 +57,10 @@ class ClimateWareHouseCrud(object):
                 encoded_params = urlencode(params)
 
                 # Construct the URL
-                url = urlparse(f"{self.url}{path}?{encoded_params}")
+                url_obj = urlparse(f"{self.url}{path}?{encoded_params}")
+                url = url_obj.geturl()
 
-                response = requests.get(url.geturl(), headers=self._headers())
+                response = requests.get(url, headers=self._headers())
                 if response.status_code != requests.codes.ok:
                     logger.error(f"Request Url: {response.url} Error Message: {response.text}")
                     raise error_code.internal_server_error(message="API Call Failure")
@@ -71,7 +72,7 @@ class ClimateWareHouseCrud(object):
                     return all_data
 
                 try:
-                    if data["page"] and data["pageCount"] and data["data"]:
+                    if data["page"] and (data["pageCount"] >= 0) and len(data["data"]) >= 0: # page count can be 0 (as of when this was written)
                         all_data.extend(data["data"]) # Add data from the current page
                     else:
                         all_data.append(data) # data was not paginated, append and return

--- a/app/crud/db.py
+++ b/app/crud/db.py
@@ -63,14 +63,21 @@ class DBCrudBase(object):
             raise errorcode.internal_server_error(message="Select DB Failure")
 
     def select_activity_with_pagination(
-        self, model: Any, filters: Any, order_by: Any, limit: int, page: int
+            self, model: Any, filters: Any, order_by: Any, limit: int = None, page: int = None
     ) -> Tuple[Any, int]:
         try:
             query = self.db.query(model).filter(or_(*filters["or"]), and_(*filters["and"]))
-            return (
-                (query.order_by(*order_by).limit(limit).offset((page - 1) * limit).all()),
-                query.count(),
-            )
+
+            if limit is not None and page is not None:
+                return (
+                    (query.order_by(*order_by).limit(limit).offset((page - 1) * limit).all()),
+                    query.count(),
+                )
+            else:
+                return (
+                    (query.order_by(*order_by).all()),
+                    query.count(),
+                )
         except Exception as e:
             logger.error(f"Select DB Failure:{e}")
             raise errorcode.internal_server_error(message="Select DB Failure")

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -6,7 +6,7 @@ from app.schemas.activity import (  # noqa: F401
     ActivityBase,
     ActivitySearchBy,
     ActivityWithCW,
-    ActivityByCwUnitIdResponse
+    ActivityRecordResponse
 )
 from app.schemas.key import Key  # noqa: F401
 from app.schemas.metadata import (  # noqa: F401

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -6,6 +6,7 @@ from app.schemas.activity import (  # noqa: F401
     ActivityBase,
     ActivitySearchBy,
     ActivityWithCW,
+    ActivityByCwUnitIdResponse
 )
 from app.schemas.key import Key  # noqa: F401
 from app.schemas.metadata import (  # noqa: F401

--- a/app/schemas/activity.py
+++ b/app/schemas/activity.py
@@ -45,6 +45,7 @@ class Activity(ActivityBase):
     vintage_year: int
     sequence_num: int
     asset_id: bytes
+    coin_id: bytes
 
 
 class ActivityWithCW(ActivityBase):

--- a/app/schemas/activity.py
+++ b/app/schemas/activity.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import enum
+from email.policy import default
 from typing import Any, Dict, List, Optional, Union
 
 from pydantic import Field, validator
@@ -59,7 +60,4 @@ class ActivitiesResponse(BaseModel):
     total: int = 0
 
 class ActivityByCwUnitIdResponse(BaseModel):
-    activity: ActivityWithCW = Field(default_factory=ActivityWithCW)
-
-class ActivityByCwUnitIdRequest(BaseModel):
-    cw_unit_id: str = Field(example='bd941858-f8b0-4327-839f-0c13f46e181e')
+    activity: ActivityWithCW = Field(default=None)

--- a/app/schemas/activity.py
+++ b/app/schemas/activity.py
@@ -57,3 +57,9 @@ class ActivityWithCW(ActivityBase):
 class ActivitiesResponse(BaseModel):
     activities: List[ActivityWithCW] = Field(default_factory=list)
     total: int = 0
+
+class ActivityByCwUnitIdResponse(BaseModel):
+    activity: ActivityWithCW = Field(default_factory=ActivityWithCW)
+
+class ActivityByCwUnitIdRequest(BaseModel):
+    cw_unit_id: str = Field(example='bd941858-f8b0-4327-839f-0c13f46e181e')

--- a/app/schemas/activity.py
+++ b/app/schemas/activity.py
@@ -59,5 +59,5 @@ class ActivitiesResponse(BaseModel):
     activities: List[ActivityWithCW] = Field(default_factory=list)
     total: int = 0
 
-class ActivityByCwUnitIdResponse(BaseModel):
+class ActivityRecordResponse(BaseModel):
     activity: ActivityWithCW = Field(default=None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "Chia Climate Token Driver"
-version = "1.0.38"
+version = "1.0.39"
 description = "https://github.com/Chia-Network/climate-token-driver"
 authors = ["Harry Hsu <stmharry@hashgreen.net>",
            "Chia Network Inc <hello@chia.net>"]


### PR DESCRIPTION
this PR adds the `/activities/activitty-record` resource. this resource allows the retrieval of a specific activity record based on the warehouse unit id, coin id, and the activity mode. These parameters are specified via the `cw_unit_id`, `coin_id`, and `action_mode` query parameters respectively. all 3 query params are required. the coin id has been added to each activity record returned by `/activities`