### PR TITLE
Remove chia-blockchain submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "chia-blockchain"]
-	path = chia-blockchain
-	url = ../chia-blockchain.git


### PR DESCRIPTION
Note, since all the test infrastructure for `chia-blockchain` has been included in the wheel, the submodule here should not be needed as any possible code needing to be imported should be available through the `chia-blockchain` installed via poetry in `pyproject.toml`