### PR TITLE
exclude auto-generated CHANGELOG.md from prettier

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,5 +36,6 @@ repos:
   - hooks:
       - id: prettier
         types_or: [ini, json, toml, yaml, markdown]
+        exclude: CHANGELOG.md
     repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.1.0


### PR DESCRIPTION
Exclude auto-generated CHANGELOG.md from prettier pre-commit check