### PR TITLE
Bump core operations to python3.12

### DIFF
--- a/.github/workflows/build-installers.yaml
+++ b/.github/workflows/build-installers.yaml
@@ -118,7 +118,7 @@ jobs:
       - name: Setup Python
         uses: Chia-Network/actions/setup-python@main
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
       - name: Create .env file
         shell: bash

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Python
         uses: Chia-Network/actions/setup-python@main
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
       - name: Create virtual environment
         uses: Chia-Network/actions/create-venv@main


### PR DESCRIPTION
This PR uses python3.12 as the default for core operations since python3.10 is the next python to be EOL.